### PR TITLE
[BUGFIX|FEATURE] Support for macro & alternative filter names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = function(nunjucks) {
         var translate = function(defaultText, textId, kwargs) {
             kwargs = kwargs || {};
 
-            var locale = this.ctx[options.locale];
+            var locale = this.ctx[options.locale] || options.env.getGlobal(options.locale);
             var text = (options.translations[locale] || {})[textId]  || defaultText;
 
             // Replace arguments

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = function(nunjucks) {
         var translate = function(defaultText, textId, kwargs) {
             kwargs = kwargs || {};
 
-            // Conver text id to lower case
+            // Convert text id to lower case
             if (options.textIdLowerCase) {
                 textId = textId.toLowerCase()
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ module.exports = function(nunjucks) {
 
         options = _.defaults(options || {}, {
             translations: {},
-            locale: "__locale__"
+            locale: "__locale__",
+            alternativeFilterNames: null
         });
 
         var translate = function(defaultText, textId, kwargs) {
@@ -42,5 +43,11 @@ module.exports = function(nunjucks) {
 
         // Add filter
         options.env.addFilter("i18n", translate);
+        // Add filter under alternative names, if provided
+        if (options.alternativeFilterNames && options.alternativeFilterNames.length) {
+            options.alternativeFilterNames.forEach(function(alternativeFilterName) {
+                options.env.addFilter(alternativeFilterName, translate)
+            })
+        }
     };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,17 @@ module.exports = function(nunjucks) {
         options = _.defaults(options || {}, {
             translations: {},
             locale: "__locale__",
-            alternativeFilterNames: null
+            alternativeFilterNames: null,
+            textIdLowerCase: false
         });
 
         var translate = function(defaultText, textId, kwargs) {
             kwargs = kwargs || {};
+
+            // Conver text id to lower case
+            if (options.textIdLowerCase) {
+                textId = textId.toLowerCase()
+            }
 
             var locale = this.ctx[options.locale] || options.env.getGlobal(options.locale);
             var text = (options.translations[locale] || {})[textId]  || defaultText;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Nunjucks i18n extension",
     "main": "lib/index.js",
     "dependencies": {
-        "lodash": "2.4.1"
+        "lodash": "^2.4.1 || ^3.0.0 || ^4.0.0"
     },
     "devDependencies": {
         "nunjucks": "*",


### PR DESCRIPTION
**[BUGFIX] Translation not working in imported template (macro)**

If no context variable with the name `option.locale` is set, try the
given environments global variables to find the locale.

**[FEATURE] Allow alternative filter names**